### PR TITLE
Fix Error in Update

### DIFF
--- a/Pegelstand/module.php
+++ b/Pegelstand/module.php
@@ -44,7 +44,11 @@ class SymconPegelstand extends IPSModule
 		
 		$pegelDataJSON = @file_get_contents($pegelUrl);
 		$pegelData = json_decode($pegelDataJSON);
-		
+		if ($pegelData == NULL)
+		{
+			echo 'Error on read Pegelonline';
+			return;
+		}
 		$pegelStandAktuell = $pegelData->value;
 		$this->SetValueFloat("Pegelaktuell", $pegelStandAktuell);
 		
@@ -66,17 +70,6 @@ class SymconPegelstand extends IPSModule
     	return true;
   	}
    
-    private function SetValueString($Ident, $Value)
-    {
-    		$id = $this->GetIDforIdent($Ident);
-    		if (GetValueString($id) <> $Value)
-    		{
-    				SetValueString($id, $Value);
-    				return true;
-    		}
-    		return false;
-  	}
-	
 	private function CreateVarProfilePGLTendenz() {
 		if (!IPS_VariableProfileExists("PGL.Tendenz")) {
 			IPS_CreateVariableProfile("PGL.Tendenz", 1);


### PR DESCRIPTION
Wenn pegelonline nicht erreichbar Meldung im Log erzeugen und abbrechen.
Sonst kommen folgende Fehlermeldungen, welche nicht weiterhelfen:
 Pegelstandsanzeige (UpdatePegelstand): <br />
<b>Notice</b>:  Trying to get property of non-object in <b>C:\IP-Symcon\modules\SymconPegelstand\Pegelstand\module.php</b> on line <b>48</b><br />
<br />
<b>Notice</b>:  Trying to get property of non-object in <b>C:\IP-Symcon\modules\SymconPegelstand\Pegelstand\module.php</b> on line <b>51</b><br />